### PR TITLE
MissingReferenceIds

### DIFF
--- a/ARM/BIO-azuredeploy-subscription.json
+++ b/ARM/BIO-azuredeploy-subscription.json
@@ -1598,6 +1598,7 @@
                         ]
                     },
                     {
+                        "policyDefinitionReferenceId": "AzureEdgeHardwareCenterDevicesShouldHaveDoubleEncryptionSupportEnabled",
                         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/08a6b96f-576e-47a2-8511-119a212d344d",
                         "parameters": {},
                         "groupNames": [
@@ -1607,6 +1608,8 @@
                         ]
                     },
                     {
+
+                        "policyDefinitionReferenceId": "AzureBatchPoolsShouldHaveDiskEncryptionEnabled",
                         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/1760f9d4-7206-436e-a28f-d9f3a5c8a227",
                         "parameters": {},
                         "groupNames": [
@@ -1643,6 +1646,7 @@
                         ]
                     },
                     {
+                        "policyDefinitionReferenceId": "VirtualMachinesAndVirtualMachineScaleSetsShouldHaveEncryptionAtHostEnabled",
                         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/fc4d8e41-e223-45ea-9bf5-eada37891d87",
                         "parameters": {},
                         "groupNames": [

--- a/ARM/BIO-azuredeploy.json
+++ b/ARM/BIO-azuredeploy.json
@@ -4296,6 +4296,7 @@
                         ]
                     },
                     {
+                        "policyDefinitionReferenceId": "AzureEdgeHardwareCenterDevicesShouldHaveDoubleEncryptionSupportEnabled",
                         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/08a6b96f-576e-47a2-8511-119a212d344d",
                         "parameters": {
                             "effect": {
@@ -4309,6 +4310,7 @@
                         ]
                     },
                     {
+                        "policyDefinitionReferenceId": "AzureBatchPoolsShouldHaveDiskEncryptionEnabled",
                         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/1760f9d4-7206-436e-a28f-d9f3a5c8a227",
                         "parameters": {
                             "effect": {
@@ -4361,6 +4363,7 @@
                         ]
                     },
                     {
+                        "policyDefinitionReferenceId": "VirtualMachinesAndVirtualMachineScaleSetsShouldHaveEncryptionAtHostEnabled",
                         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/fc4d8e41-e223-45ea-9bf5-eada37891d87",
                         "parameters": {
                             "effect": {


### PR DESCRIPTION
Some empty policy referenceIds, otherwise random numbers will be the id and this way they are easier to exempt if needed.