### PR TITLE
FixpDefRefIdNameAndAddBackupPolicy

### DIFF
--- a/ARM/BIO-azuredeploy-subscription.json
+++ b/ARM/BIO-azuredeploy-subscription.json
@@ -1957,15 +1957,14 @@
                         "policyDefinitionReferenceId": "ConfigureBackupOnVirtualMachinesWithoutAGivenTagToANewRecoveryServicesVaultWithADefaultPolicy",
                         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86",
                         "parameters": {
+                            "effect": {
+                                "value": "[[parameters('effect-98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86')]"
+                            },
                             "exclusionTagName": {
-                                "value": "excludeBackup"
+                                "value": "[[parameters('exclusionTagName-98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86')]"
                             },
                             "exclusionTagValue": {
-                               "value": [
-                                    "Yes",
-                                    "yes",
-                                    "YES"
-                                ]
+                                "value": "[[parameters('exclusionTagValue-98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86')]"
                             }
                         },
                         "groupNames": [

--- a/ARM/BIO-azuredeploy-subscription.json
+++ b/ARM/BIO-azuredeploy-subscription.json
@@ -1710,7 +1710,7 @@
                         ]
                     },
                     {
-                        "policyDefinitionReferenceId": "StorageAccountsShouldHaveInfrastructureEncryption",
+                        "policyDefinitionReferenceId": "TempDisksAndCacheForAgentNodePoolsInAzureKubernetesServiceClustersShouldBeEncryptedAtHost",
                         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/41425d9f-d1a5-499a-9932-f8ed8453932c",
                         "parameters": {},
                         "groupNames": [
@@ -1954,8 +1954,8 @@
                         ]
                     },
                     {
-                        "policyDefinitionReferenceId": "EnsureProtectionOfYourAzureVirtualMachinesByEnablingAzureBackup",
-                        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/013e242c-8828-4970-87b3-ab247555486d",
+                        "policyDefinitionReferenceId": "ConfigureBackupOnVirtualMachinesWithoutAGivenTagToANewRecoveryServicesVaultWithADefaultPolicy",
+                        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86",
                         "parameters": {},
                         "groupNames": [
                             "U.03.1 - Redundantie",

--- a/ARM/BIO-azuredeploy-subscription.json
+++ b/ARM/BIO-azuredeploy-subscription.json
@@ -1033,6 +1033,38 @@
                     }
                 ],
                 "parameters": {
+                    "effect-98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86": {
+                        "type": "String",
+                        "defaultValue": "AuditIfNotExists",
+                        "allowedValues": [
+                            "auditIfNotExists",
+                            "AuditIfNotExists",
+                            "deployIfNotExists",
+                            "DeployIfNotExists",
+                            "disabled",
+                            "Disabled"
+                        ],
+                        "metadata": {
+                            "displayName": "Effect for policy: Configure backup on virtual machines without a given tag to a new recovery services vault with a default policy",
+                            "description": "The effect determines what happens when the policy rule is evaluated to match; for more information about effects, visit https://aka.ms/policyeffects"
+                        }
+                    },
+                    "exclusionTagName-98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86": {
+                        "type": "String",
+                        "defaultValue": "",
+                        "metadata": {
+                            "displayName": "Exclusion Tag Name",
+                            "description": "Name of the tag to use for excluding VMs from the scope of this policy. This should be used along with the Exclusion Tag Value parameter. Learn more at https://aka.ms/AppCentricVMBackupPolicy."
+                        }
+                    },
+                    "exclusionTagValue-98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86": {
+                        "type": "Array",
+                        "defaultValue": [],
+                        "metadata": {
+                            "displayName": "Exclusion Tag Values",
+                            "description": "Value of the tag to use for excluding VMs from the scope of this policy (in case of multiple values, use a comma-separated list). This should be used along with the Exclusion Tag Name parameter. Learn more at https://aka.ms/AppCentricVMBackupPolicy."
+                        }
+                    },
                     "listOfAllowedLocations": {
                         "type": "array",
                         "defaultValue": [

--- a/ARM/BIO-azuredeploy-subscription.json
+++ b/ARM/BIO-azuredeploy-subscription.json
@@ -1956,7 +1956,18 @@
                     {
                         "policyDefinitionReferenceId": "ConfigureBackupOnVirtualMachinesWithoutAGivenTagToANewRecoveryServicesVaultWithADefaultPolicy",
                         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86",
-                        "parameters": {},
+                        "parameters": {
+                            "exclusionTagName": {
+                                "value": "excludeBackup"
+                            },
+                            "exclusionTagValue": {
+                               "value": [
+                                    "Yes",
+                                    "yes",
+                                    "YES"
+                                ]
+                            }
+                        },
                         "groupNames": [
                             "U.03.1 - Redundantie",
                             "U.03.2 - Continuïteitseisen",

--- a/ARM/BIO-azuredeploy.json
+++ b/ARM/BIO-azuredeploy.json
@@ -1999,15 +1999,19 @@
                             "description": "The effect determines what happens when the policy rule is evaluated to match; for more information about effects, visit https://aka.ms/policyeffects"
                         }
                     },
-                    "effect-013e242c-8828-4970-87b3-ab247555486d": {
+                    "effect-98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86": {
                         "type": "String",
                         "defaultValue": "AuditIfNotExists",
                         "allowedValues": [
+                            "auditIfNotExists",
                             "AuditIfNotExists",
+                            "deployIfNotExists",
+                            "DeployIfNotExists",
+                            "disabled",
                             "Disabled"
                         ],
                         "metadata": {
-                            "displayName": "Effect for policy: Azure Backup should be enabled for Virtual Machines",
+                            "displayName": "Effect for policy: Configure backup on virtual machines without a given tag to a new recovery services vault with a default policy",
                             "description": "The effect determines what happens when the policy rule is evaluated to match; for more information about effects, visit https://aka.ms/policyeffects"
                         }
                     },
@@ -4455,7 +4459,7 @@
                         ]
                     },
                     {
-                        "policyDefinitionReferenceId": "StorageAccountsShouldHaveInfrastructureEncryption",
+                        "policyDefinitionReferenceId": "TempDisksAndCacheForAgentNodePoolsInAzureKubernetesServiceClustersShouldBeEncryptedAtHost",
                         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/41425d9f-d1a5-499a-9932-f8ed8453932c",
                         "parameters": {
                             "effect": {
@@ -4782,11 +4786,11 @@
                         ]
                     },
                     {
-                        "policyDefinitionReferenceId": "EnsureProtectionOfYourAzureVirtualMachinesByEnablingAzureBackup",
-                        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/013e242c-8828-4970-87b3-ab247555486d",
+                        "policyDefinitionReferenceId": "ConfigureBackupOnVirtualMachinesWithoutAGivenTagToANewRecoveryServicesVaultWithADefaultPolicy",
+                        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86",
                         "parameters": {
                             "effect": {
-                                "value": "[[parameters('effect-013e242c-8828-4970-87b3-ab247555486d')]"
+                                "value": "[[parameters('effect-98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86')]"
                             }
                         },
                         "groupNames": [

--- a/ARM/BIO-azuredeploy.json
+++ b/ARM/BIO-azuredeploy.json
@@ -4791,13 +4791,23 @@
                         "parameters": {
                             "effect": {
                                 "value": "[[parameters('effect-98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86')]"
-                            }
+                            },
+                            "exclusionTagName": {
+                                "value": "excludeBackup"
+                            },
+                            "exclusionTagValue": {
+                               "value": [
+                                    "Yes",
+                                    "yes",
+                                    "YES"
+                                ]
                         },
                         "groupNames": [
                             "U.03.1 - Redundantie",
                             "U.03.2 - Continuïteitseisen",
                             "U.17.1 - Versleuteld"
                         ]
+                        }
                     },
                     {
                         "policyDefinitionReferenceId": "VulnerabilityAssessmentShouldBeEnabledOnYourSynapseWorkspaces",

--- a/ARM/BIO-azuredeploy.json
+++ b/ARM/BIO-azuredeploy.json
@@ -2015,6 +2015,22 @@
                             "description": "The effect determines what happens when the policy rule is evaluated to match; for more information about effects, visit https://aka.ms/policyeffects"
                         }
                     },
+                    "exclusionTagName-98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86": {
+                        "type": "String",
+                        "defaultValue": "",
+                        "metadata": {
+                            "displayName": "Exclusion Tag Name",
+                            "description": "Name of the tag to use for excluding VMs from the scope of this policy. This should be used along with the Exclusion Tag Value parameter. Learn more at https://aka.ms/AppCentricVMBackupPolicy."
+                        }
+                    },
+                    "exclusionTagValue-98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86": {
+                        "type": "Array",
+                        "defaultValue": [],
+                        "metadata": {
+                            "displayName": "Exclusion Tag Values",
+                            "description": "Value of the tag to use for excluding VMs from the scope of this policy (in case of multiple values, use a comma-separated list). This should be used along with the Exclusion Tag Name parameter. Learn more at https://aka.ms/AppCentricVMBackupPolicy."
+                        }
+                    },
                     "effect-0049a6b3-a662-4f3e-8635-39cf44ace45a": {
                         "type": "String",
                         "defaultValue": "AuditIfNotExists",
@@ -4793,21 +4809,17 @@
                                 "value": "[[parameters('effect-98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86')]"
                             },
                             "exclusionTagName": {
-                                "value": "excludeBackup"
+                                "value": "[[parameters('exclusionTagName-98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86')]"
                             },
                             "exclusionTagValue": {
-                               "value": [
-                                    "Yes",
-                                    "yes",
-                                    "YES"
-                                ]
+                                "value": "[[parameters('exclusionTagValue-98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86')]"
+                            }
                         },
                         "groupNames": [
                             "U.03.1 - Redundantie",
                             "U.03.2 - Continuïteitseisen",
                             "U.17.1 - Versleuteld"
                         ]
-                        }
                     },
                     {
                         "policyDefinitionReferenceId": "VulnerabilityAssessmentShouldBeEnabledOnYourSynapseWorkspaces",


### PR DESCRIPTION
Definition Reference Id Name for 41425d9f-d1a5-499a-9932-f8ed8453932c was incorrect
Backup policy that was used (013e242c-8828-4970-87b3-ab247555486d) had no support for exclusion tags, the new configured policy (98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86)  does have that support. 